### PR TITLE
Library unusable after cleanup commit, here is a fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
                                 <unzip src="${project.build.directory}/${project.artifactId}.zip" dest="${project.build.directory}" />
                                 <echo message="moving resources" />
                                 <move todir="${destDir}">
-                                    <fileset dir="${project.build.directory}/dygraphs-${upstream.version}" includes="dygraph-*.js" />
+                                    <fileset dir="${project.build.directory}/dygraphs-${upstream.version}" excludes="dygraph-combined.js" />
                                 </move>
                             </target>
                         </configuration>


### PR DESCRIPTION
I realize it's hard to test all of these js libs. I've created a project showing basic usage of the library. Please clone, build and run :
https://github.com/cschroed-usgs/DygraphsUsage
You will see that neither the dev nor the combined examples work with the current release of webjars/dygraphs. If you clone, build, and package this pull request, and increment the pom in DygraphsUsage to point at your local snapshot artifact, it will work.

I really like the idea of downloading the dygraph-combined.js from the project's website because it removes the platform-dependent shell script build step. However, in the current release of webjar/dygraphs, that file is overwritten when moving the unzipped files into the proper directory, leaving it with the distribution dygraph-combined.js file, which does not work as-is. I'm not sure why upstream checks that non-working file in to the repo, but I'm not going to argue with it.

So the new exclude attribute on the move task enables us to keep the actually working dygraph-combined.js in our webjar.
I removed the include attribute from the move task because dygraph-dev.js does not work without all of the source files present. dygraph-dev.js grabs various files from various directories in the source tree and appends them as script elements to the html doc. I do not recommend using an include attribute to selectively include files because as the library evolves, dygraph-dev.js will likely pull many different files from many different places in the source tree. If we include everything, we can avoid updating the include filter for each Dygraphs release.
