### PR TITLE
Dygraphs Dev Script Unusable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
                                 <unzip src="${project.build.directory}/${project.artifactId}.zip" dest="${project.build.directory}" />
                                 <echo message="moving resources" />
                                 <move todir="${destDir}">
-                                    <fileset dir="${project.build.directory}/dygraphs-${upstream.version}" includes="dygraph-*.js" />
+                                    <fileset dir="${project.build.directory}/dygraphs-${upstream.version}" excludes="dygraph-combined.js" />
                                 </move>
                             </target>
                         </configuration>


### PR DESCRIPTION
Hi James,

Thank you for incorporating the working production script of Dygraphs in the last pull request.
I've updated the DygraphsUsage project to use the 1.0.1-1 release.
https://github.com/cschroed-usgs/DygraphsUsage
As you can see when you run the Usage project, the dev version of Dygraphs does not work. Please include the necessary files in the webjar so that dygraph-dev.js can work.

Please let me know if you have any questions.

Cheers!
